### PR TITLE
fix: fail liveness probe when replication heartbeat is stale

### DIFF
--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -158,7 +158,7 @@ func (l *Listener) liveness(w http.ResponseWriter, _ *http.Request) {
 
 	w.Header().Set("Content-Type", contentTypeTextPlain)
 
-	if !l.replicator.IsAlive() || !l.repository.IsAlive() {
+	if !l.replicator.IsAlive() || !l.repository.IsAlive() || !l.isAlive.Load() {
 		resp = []byte("failed")
 		respCode = http.StatusInternalServerError
 


### PR DESCRIPTION
The liveness probe only checked conn.IsClosed(), which reports an explicitly closed connection but not a network-dead one. On a Postgres primary failover, the replication connection to the old primary goes silently dead: the periodic heartbeat fails and flips isAlive to false (so /ready returns 500), but /healthz stayed green and k8s never restarted the pod. The pod then ran indefinitely pointing at the old primary.

Include isAlive in the liveness check so a stalled heartbeat fails /healthz, letting Kubernetes restart the pod and reconnect to the new primary through the Service.